### PR TITLE
effects: add a hercules CI effect for deploying ardana tenant

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -153,6 +153,26 @@
         "type": "github"
       }
     },
+    "hci-effects": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1655158531,
+        "narHash": "sha256-5LeaONqA6pgSNeA39gzu5XUipw3mXNZ04LUiy2TVImU=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "bda248e06dc44cbba9f4db350abbb10c3fe3b6fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "type": "github"
+      }
+    },
     "nixinate": {
       "inputs": {
         "nixpkgs": [

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,15 @@
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-22.05";
+
     nixinate.url = "github:matthewcroughan/nixinate";
     nixinate.inputs.nixpkgs.follows = "nixpkgs";
+
+    hci-effects.url = "github:hercules-ci/hercules-ci-effects";
+    hci-effects.inputs.nixpkgs.follows = "nixpkgs";
+
     danaswapstats.url = "git+ssh://git@github.com/ArdanaLabs/danaswapstats";
     dana-circulating-supply.url = "git+ssh://git@github.com/ArdanaLabs/dana-circulating-supply?ref=main";
-    hci-effects.url = "github:hercules-ci/hercules-ci-effects";
   };
   outputs = {
     self,


### PR DESCRIPTION
Adds a HCI effect for deploying to ardana tenant machine. ~~This will require an SSH key to be setup on the HCI agent. Also see https://github.com/ArdanaLabs/dana-circulating-supply/pull/16. We'll also need to add this repo to HCI~~