### PR TITLE
flake: update hello-cardano-template using cardano-node 1.35.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -32,6 +32,22 @@
         "type": "github"
       }
     },
+    "HTTP_11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
     "HTTP_2": {
       "flake": false,
       "locked": {
@@ -198,7 +214,7 @@
       "inputs": {
         "flakeCompat": "flakeCompat",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "dream2nix",
           "nixpkgs"
         ]
@@ -221,7 +237,7 @@
       "inputs": {
         "flakeCompat": "flakeCompat_2",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "yubihsm",
           "nci",
           "dream2nix",
@@ -248,7 +264,7 @@
         "flake-compat-ci": "flake-compat-ci",
         "haskell-nix": "haskell-nix",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "apropos",
           "haskell-nix",
           "nixpkgs-unstable"
@@ -296,13 +312,13 @@
         "cardano-node": "cardano-node_2",
         "cardano-prelude": "cardano-prelude",
         "cardano-wallet": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "cardano-wallet"
         ],
         "ekg-forward": "ekg-forward",
         "ekg-json": "ekg-json",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_4",
         "flat": "flat",
         "goblins": "goblins",
         "haskell-nix": "haskell-nix_2",
@@ -313,16 +329,16 @@
         "iohk-monitoring-framework": "iohk-monitoring-framework",
         "iohk-nix": "iohk-nix",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "bot-plutus-interface",
           "haskell-nix",
           "nixpkgs-unstable"
         ],
         "optparse-applicative": "optparse-applicative",
-        "ouroboros-network": "ouroboros-network_4",
+        "ouroboros-network": "ouroboros-network_3",
         "plutus": "plutus",
-        "plutus-apps": "plutus-apps",
+        "plutus-apps": "plutus-apps_3",
         "purescript-bridge": "purescript-bridge",
         "quickcheck-dynamic": "quickcheck-dynamic",
         "servant-purescript": "servant-purescript",
@@ -392,14 +408,31 @@
         "type": "github"
       }
     },
+    "cabal-32_11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-32_2": {
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
-        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
         "type": "github"
       },
       "original": {
@@ -464,10 +497,10 @@
       "flake": false,
       "locked": {
         "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "narHash": "sha256-sDbrmur9Zfp4mPKohCD8IDZfXJ0Tjxpmr2R+kg5PpSY=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "rev": "94aaa8e4720081f9c75497e2735b90f6a819b08e",
         "type": "github"
       },
       "original": {
@@ -562,14 +595,31 @@
         "type": "github"
       }
     },
+    "cabal-34_11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-34_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1622475795,
-        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
+        "lastModified": 1640353650,
+        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
+        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
         "type": "github"
       },
       "original": {
@@ -633,11 +683,11 @@
     "cabal-34_6": {
       "flake": false,
       "locked": {
-        "lastModified": 1640353650,
-        "narHash": "sha256-N1t6M3/wqj90AEdRkeC8i923gQYUpzSr8b40qVOZ1Rk=",
+        "lastModified": 1622475795,
+        "narHash": "sha256-chwTL304Cav+7p38d9mcb+egABWmxo2Aq+xgVBgEb/U=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "942639c18c0cd8ec53e0a6f8d120091af35312cd",
+        "rev": "b086c1995cdd616fc8d91f46a21e905cc50a1049",
         "type": "github"
       },
       "original": {
@@ -715,14 +765,31 @@
         "type": "github"
       }
     },
+    "cabal-36_10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-36_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1640163203,
-        "narHash": "sha256-TwDWP2CffT0j40W6zr0J1Qbu+oh3nsF1lUx9446qxZM=",
+        "lastModified": 1641652457,
+        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "ecf418050c1821f25e2e218f1be94c31e0465df1",
+        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
         "type": "github"
       },
       "original": {
@@ -769,11 +836,11 @@
     "cabal-36_5": {
       "flake": false,
       "locked": {
-        "lastModified": 1641652457,
-        "narHash": "sha256-BlFPKP4C4HRUJeAbdembX1Rms1LD380q9s0qVDeoAak=",
+        "lastModified": 1640163203,
+        "narHash": "sha256-TwDWP2CffT0j40W6zr0J1Qbu+oh3nsF1lUx9446qxZM=",
         "owner": "haskell",
         "repo": "cabal",
-        "rev": "f27667f8ec360c475027dcaee0138c937477b070",
+        "rev": "ecf418050c1821f25e2e218f1be94c31e0465df1",
         "type": "github"
       },
       "original": {
@@ -865,57 +932,6 @@
         "owner": "input-output-hk",
         "repo": "cardano-addresses",
         "rev": "b7273a5d3c21f1a003595ebf1e1f79c28cd72513",
-        "type": "github"
-      }
-    },
-    "cardano-app-template": {
-      "inputs": {
-        "apropos": "apropos",
-        "cardano-node": "cardano-node",
-        "cardano-ogmios": "cardano-ogmios",
-        "cardano-transaction-lib": "cardano-transaction-lib",
-        "digraph": "digraph",
-        "dream2nix": "dream2nix",
-        "flake-parts": "flake-parts_2",
-        "haskell-nix": "haskell-nix_3",
-        "jquery": "jquery",
-        "lighthouse-src": "lighthouse-src",
-        "lint-utils": "lint-utils",
-        "mlabs-ogmios": [
-          "cardano-app-template",
-          "cardano-transaction-lib",
-          "ogmios"
-        ],
-        "nixpkgs": "nixpkgs_16",
-        "npmlock2nix": "npmlock2nix",
-        "ogmios-datum-cache": [
-          "cardano-app-template",
-          "cardano-transaction-lib",
-          "ogmios-datum-cache"
-        ],
-        "plutarch": "plutarch",
-        "plutus": "plutus_4",
-        "ps-tools": [
-          "cardano-app-template",
-          "purs-nix",
-          "ps-tools"
-        ],
-        "purs-nix": "purs-nix",
-        "treefmt-flake": "treefmt-flake",
-        "yubihsm": "yubihsm"
-      },
-      "locked": {
-        "lastModified": 1665535852,
-        "narHash": "sha256-4uXzxZ8lYEv6R6KiFtzpDZqerrrcW2YTfOzfmgbiR7s=",
-        "owner": "ArdanaLabs",
-        "repo": "cardano-app-template",
-        "rev": "0262bd5c1a117e1b13d71accd586ec13c21e1406",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ArdanaLabs",
-        "ref": "hello-world-nixos-module",
-        "repo": "cardano-app-template",
         "type": "github"
       }
     },
@@ -1089,7 +1105,7 @@
     },
     "cardano-mainnet-mirror": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1108,7 +1124,7 @@
     },
     "cardano-mainnet-mirror_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_7"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1127,7 +1143,7 @@
     },
     "cardano-mainnet-mirror_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -1146,76 +1162,62 @@
     },
     "cardano-node": {
       "inputs": {
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror",
+        "cardano-node-workbench": [
+          "hello-cardano-template",
+          "cardano-node-workbench"
+        ],
         "customConfig": "customConfig",
+        "flake-compat": "flake-compat_2",
+        "hackageNix": "hackageNix",
         "haskellNix": "haskellNix",
+        "hostNixpkgs": [
+          "hello-cardano-template",
+          "cardano-node",
+          "nixpkgs"
+        ],
         "iohkNix": "iohkNix",
-        "membench": "membench",
+        "nixTools": "nixTools",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
           "haskellNix",
-          "nixpkgs-2105"
+          "nixpkgs-unstable"
         ],
+        "node-measured": [
+          "hello-cardano-template",
+          "cardano-node-workbench"
+        ],
+        "node-process": "node-process",
+        "node-snapshot": "node-snapshot",
+        "plutus-apps": "plutus-apps",
         "utils": "utils_4"
       },
       "locked": {
-        "lastModified": 1646407906,
-        "narHash": "sha256-e4k1vCsZqUB/I3uPRDIKP9pZ81E/zosJn8kXySAfBcI=",
+        "lastModified": 1659625017,
+        "narHash": "sha256-4IrheFeoWfvkZQndEk4fGUkOiOjcVhcyXZ6IqmvkDgg=",
         "owner": "input-output-hk",
         "repo": "cardano-node",
-        "rev": "73f9a746362695dc2cb63ba757fbcabb81733d23",
+        "rev": "950c4e222086fed5ca53564e642434ce9307b0b9",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "1.35.3",
         "repo": "cardano-node",
-        "rev": "73f9a746362695dc2cb63ba757fbcabb81733d23",
         "type": "github"
       }
     },
     "cardano-node-snapshot": {
       "inputs": {
-        "customConfig": "customConfig_2",
-        "haskellNix": "haskellNix_2",
-        "iohkNix": "iohkNix_2",
-        "membench": "membench_2",
-        "nixpkgs": [
-          "cardano-app-template",
-          "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
-          "haskellNix",
-          "nixpkgs-2105"
-        ],
-        "plutus-example": "plutus-example",
-        "utils": "utils_3"
-      },
-      "locked": {
-        "lastModified": 1645120669,
-        "narHash": "sha256-2MKfGsYS5n69+pfqNHb4IH/E95ok1MD7mhEYfUpRcz4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-node",
-        "rev": "7f00e3ea5a61609e19eeeee4af35241571efdf5c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-node",
-        "rev": "30d62b86e7b98da28ef8ad9412e4e00a1ba1231d",
-        "type": "github"
-      }
-    },
-    "cardano-node-snapshot_2": {
-      "inputs": {
         "customConfig": "customConfig_3",
         "haskellNix": "haskellNix_3",
         "iohkNix": "iohkNix_3",
-        "membench": "membench_3",
+        "membench": "membench_2",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "membench",
           "cardano-node-snapshot",
           "haskellNix",
@@ -1235,6 +1237,63 @@
         "owner": "input-output-hk",
         "repo": "cardano-node",
         "rev": "30d62b86e7b98da28ef8ad9412e4e00a1ba1231d",
+        "type": "github"
+      }
+    },
+    "cardano-node-workbench": {
+      "inputs": {
+        "cardano-node-workbench": "cardano-node-workbench_2",
+        "customConfig": "customConfig_5",
+        "flake-compat": "flake-compat_3",
+        "haskellNix": "haskellNix_5",
+        "hostNixpkgs": [
+          "hello-cardano-template",
+          "cardano-node-workbench",
+          "nixpkgs"
+        ],
+        "iohkNix": "iohkNix_5",
+        "membench": [
+          "hello-cardano-template",
+          "empty-flake"
+        ],
+        "nixpkgs": [
+          "hello-cardano-template",
+          "cardano-node-workbench",
+          "haskellNix",
+          "nixpkgs-2105"
+        ],
+        "plutus-apps": "plutus-apps_2",
+        "utils": "utils_5"
+      },
+      "locked": {
+        "lastModified": 1647983004,
+        "narHash": "sha256-29kzatjbzREnXoT6Yh89OC82C5qI8eCVZhm4OeSjrgw=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "ed9932c52aaa535b71f72a5b4cc0cecb3344a5a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "ed9932c52aaa535b71f72a5b4cc0cecb3344a5a3",
+        "type": "github"
+      }
+    },
+    "cardano-node-workbench_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647605822,
+        "narHash": "sha256-bhgSsshidZ7dOPpXdG88pIqhy5VgXWi3LXtR78oDiEo=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "44ac30fb04d02d41ba005ca5228db9b5e9b887d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "44ac30fb04d02d41ba005ca5228db9b5e9b887d2",
         "type": "github"
       }
     },
@@ -1275,11 +1334,11 @@
     "cardano-ogmios": {
       "inputs": {
         "config": "config",
-        "flake-utils": "flake-utils_6",
-        "haskellNix": "haskellNix_5",
-        "iohkNix": "iohkNix_5",
+        "flake-utils": "flake-utils_7",
+        "haskellNix": "haskellNix_6",
+        "iohkNix": "iohkNix_6",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-ogmios",
           "haskellNix",
           "nixpkgs-unstable"
@@ -1400,6 +1459,22 @@
       }
     },
     "cardano-shell_10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-shell_11": {
       "flake": false,
       "locked": {
         "lastModified": 1608537748,
@@ -1549,16 +1624,16 @@
         "cardano-configurations": "cardano-configurations",
         "cardano-wallet": "cardano-wallet",
         "easy-purescript-nix": "easy-purescript-nix",
-        "flake-compat": "flake-compat_5",
+        "flake-compat": "flake-compat_7",
         "haskell-nix": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "plutip",
           "haskell-nix"
         ],
         "iohk-nix": "iohk-nix_2",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "plutip",
           "nixpkgs"
@@ -1584,21 +1659,21 @@
     },
     "cardano-wallet": {
       "inputs": {
-        "customConfig": "customConfig_5",
+        "customConfig": "customConfig_6",
         "ema": "ema",
         "emanote": "emanote",
-        "flake-compat": "flake-compat_4",
-        "flake-utils": "flake-utils_12",
-        "haskellNix": "haskellNix_6",
+        "flake-compat": "flake-compat_6",
+        "flake-utils": "flake-utils_13",
+        "haskellNix": "haskellNix_7",
         "hostNixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "cardano-wallet",
           "nixpkgs"
         ],
-        "iohkNix": "iohkNix_6",
+        "iohkNix": "iohkNix_7",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "cardano-wallet",
           "haskellNix",
@@ -1759,11 +1834,26 @@
         "type": "github"
       }
     },
+    "customConfig_6": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
     "dana-circulating-supply": {
       "inputs": {
         "gitignore-src": "gitignore-src",
         "hci-effects": "hci-effects",
-        "nixpkgs": "nixpkgs_36",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-new": "nixpkgs-new"
       },
       "locked": {
@@ -1783,7 +1873,7 @@
     },
     "danalib": {
       "inputs": {
-        "nixpkgs": "nixpkgs_37"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1639723206,
@@ -1806,7 +1896,7 @@
         "easy-hls-src": "easy-hls-src",
         "gitignore-hercules-src": "gitignore-hercules-src",
         "gitignore-src": "gitignore-src_2",
-        "nixpkgs": "nixpkgs_38",
+        "nixpkgs": "nixpkgs_4",
         "safe-coloured-text-src": "safe-coloured-text-src",
         "sydtest-src": "sydtest-src",
         "validity-src": "validity-src"
@@ -1829,8 +1919,8 @@
       "inputs": {
         "fenix": "fenix",
         "naersk": "naersk",
-        "nixpkgs": "nixpkgs_25",
-        "utils": "utils_5"
+        "nixpkgs": "nixpkgs_30",
+        "utils": "utils_6"
       },
       "locked": {
         "lastModified": 1655647809,
@@ -1850,8 +1940,8 @@
       "inputs": {
         "fenix": "fenix_2",
         "naersk": "naersk_2",
-        "nixpkgs": "nixpkgs_29",
-        "utils": "utils_6"
+        "nixpkgs": "nixpkgs_34",
+        "utils": "utils_7"
       },
       "locked": {
         "lastModified": 1656370114,
@@ -1885,8 +1975,8 @@
     },
     "devshell_2": {
       "inputs": {
-        "flake-utils": "flake-utils_22",
-        "nixpkgs": "nixpkgs_32"
+        "flake-utils": "flake-utils_23",
+        "nixpkgs": "nixpkgs_37"
       },
       "locked": {
         "lastModified": 1650900878,
@@ -1944,7 +2034,7 @@
         "gomod2nix": "gomod2nix",
         "mach-nix": "mach-nix",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "nixpkgs"
         ],
         "node2nix": "node2nix",
@@ -1972,7 +2062,7 @@
         "flake-utils-pre-commit": "flake-utils-pre-commit_2",
         "gomod2nix": "gomod2nix_2",
         "mach-nix": "mach-nix_2",
-        "nixpkgs": "nixpkgs_33",
+        "nixpkgs": "nixpkgs_38",
         "node2nix": "node2nix_2",
         "poetry2nix": "poetry2nix_2",
         "pre-commit-hooks": "pre-commit-hooks_3"
@@ -2078,9 +2168,9 @@
     },
     "ema": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_9",
-        "nixpkgs": "nixpkgs_6",
+        "flake-compat": "flake-compat_5",
+        "flake-utils": "flake-utils_10",
+        "nixpkgs": "nixpkgs_11",
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
@@ -2116,9 +2206,9 @@
     },
     "ema_3": {
       "inputs": {
-        "flake-compat": "flake-compat_9",
-        "flake-utils": "flake-utils_16",
-        "nixpkgs": "nixpkgs_17"
+        "flake-compat": "flake-compat_11",
+        "flake-utils": "flake-utils_17",
+        "nixpkgs": "nixpkgs_22"
       },
       "locked": {
         "lastModified": 1653742730,
@@ -2140,7 +2230,7 @@
         "ema": "ema_2",
         "flake-parts": "flake-parts",
         "haskell-flake": "haskell-flake",
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_14",
         "tailwind-haskell": "tailwind-haskell"
       },
       "locked": {
@@ -2161,14 +2251,14 @@
       "inputs": {
         "ema": "ema_3",
         "flake-compat": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "plutarch",
           "emanote",
           "ema",
           "flake-compat"
         ],
         "flake-utils": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "plutarch",
           "emanote",
           "ema",
@@ -2177,7 +2267,7 @@
         "heist": "heist",
         "ixset-typed": "ixset-typed",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "plutarch",
           "emanote",
           "ema",
@@ -2201,9 +2291,25 @@
         "type": "github"
       }
     },
+    "empty-flake": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      }
+    },
     "fenix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_23",
+        "nixpkgs": "nixpkgs_28",
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
@@ -2222,7 +2328,7 @@
     },
     "fenix_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_27",
+        "nixpkgs": "nixpkgs_32",
         "rust-analyzer-src": "rust-analyzer-src_2"
       },
       "locked": {
@@ -2242,7 +2348,7 @@
     "fenix_3": {
       "inputs": {
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "purs-nix",
           "statix",
           "nixpkgs"
@@ -2297,11 +2403,11 @@
     "flake-compat_10": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
         "type": "github"
       },
       "original": {
@@ -2326,23 +2432,7 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_3": {
+    "flake-compat_12": {
       "flake": false,
       "locked": {
         "lastModified": 1641205782,
@@ -2358,23 +2448,7 @@
         "type": "github"
       }
     },
-    "flake-compat_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1635892615,
-        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "rev": "eca47d3377946315596da653862d341ee5341318",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_5": {
+    "flake-compat_13": {
       "flake": false,
       "locked": {
         "lastModified": 1650374568,
@@ -2382,6 +2456,72 @@
         "owner": "edolstra",
         "repo": "flake-compat",
         "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "fixes",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "fixes",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
         "type": "github"
       },
       "original": {
@@ -2393,15 +2533,15 @@
     "flake-compat_6": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
+        "lastModified": 1635892615,
+        "narHash": "sha256-harGbMZr4hzat2BWBU+Y5OYXlu+fVz7E4WeQzHi5o8A=",
+        "owner": "input-output-hk",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "eca47d3377946315596da653862d341ee5341318",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "input-output-hk",
         "repo": "flake-compat",
         "type": "github"
       }
@@ -2425,11 +2565,11 @@
     "flake-compat_8": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1641205782,
+        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
         "type": "github"
       },
       "original": {
@@ -2456,7 +2596,7 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs": "nixpkgs_8"
+        "nixpkgs": "nixpkgs_13"
       },
       "locked": {
         "lastModified": 1655570068,
@@ -2475,7 +2615,7 @@
     "flake-parts_2": {
       "inputs": {
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "nixpkgs"
         ]
       },
@@ -2540,6 +2680,21 @@
     },
     "flake-utils_10": {
       "locked": {
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_11": {
+      "locked": {
         "lastModified": 1619345332,
         "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
         "owner": "numtide",
@@ -2553,7 +2708,7 @@
         "type": "github"
       }
     },
-    "flake-utils_11": {
+    "flake-utils_12": {
       "locked": {
         "lastModified": 1652776076,
         "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
@@ -2569,28 +2724,13 @@
         "type": "github"
       }
     },
-    "flake-utils_12": {
+    "flake-utils_13": {
       "locked": {
         "lastModified": 1653893745,
         "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_13": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -2631,6 +2771,21 @@
     },
     "flake-utils_16": {
       "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_17": {
+      "locked": {
         "lastModified": 1649676176,
         "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
@@ -2644,7 +2799,7 @@
         "type": "github"
       }
     },
-    "flake-utils_17": {
+    "flake-utils_18": {
       "locked": {
         "lastModified": 1642700792,
         "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
@@ -2659,7 +2814,7 @@
         "type": "github"
       }
     },
-    "flake-utils_18": {
+    "flake-utils_19": {
       "locked": {
         "lastModified": 1644229661,
         "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
@@ -2674,28 +2829,13 @@
         "type": "github"
       }
     },
-    "flake-utils_19": {
-      "locked": {
-        "lastModified": 1618217525,
-        "narHash": "sha256-WGrhVczjXTiswQaoxQ+0PTfbLNeOQM6M36zvLn78AYg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c6169a2772643c4a93a0b5ac1c61e296cba68544",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -2721,6 +2861,21 @@
     },
     "flake-utils_21": {
       "locked": {
+        "lastModified": 1618217525,
+        "narHash": "sha256-WGrhVczjXTiswQaoxQ+0PTfbLNeOQM6M36zvLn78AYg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c6169a2772643c4a93a0b5ac1c61e296cba68544",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_22": {
+      "locked": {
         "lastModified": 1649676176,
         "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
@@ -2734,7 +2889,7 @@
         "type": "github"
       }
     },
-    "flake-utils_22": {
+    "flake-utils_23": {
       "locked": {
         "lastModified": 1642700792,
         "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
@@ -2796,11 +2951,11 @@
     },
     "flake-utils_6": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -2811,11 +2966,11 @@
     },
     "flake-utils_7": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
         "type": "github"
       },
       "original": {
@@ -2841,11 +2996,11 @@
     },
     "flake-utils_9": {
       "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
         "type": "github"
       },
       "original": {
@@ -2969,6 +3124,23 @@
       }
     },
     "ghc-8.6.5-iohk_10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk_11": {
       "flake": false,
       "locked": {
         "lastModified": 1600920045,
@@ -3124,7 +3296,7 @@
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "purs-nix",
           "statix",
           "nixpkgs"
@@ -3345,6 +3517,22 @@
         "type": "github"
       }
     },
+    "hackageNix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1646961339,
+        "narHash": "sha256-hsXNxSugSyOALfOt0I+mXrKioJ/nWX49/RhF/88N6D0=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "5dea95d408c29b56a14faae378ae4e39d63126f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "hackage_10": {
       "flake": false,
       "locked": {
@@ -3396,11 +3584,11 @@
     "hackage_4": {
       "flake": false,
       "locked": {
-        "lastModified": 1643073363,
-        "narHash": "sha256-66oSXQKEDIOSQ2uKAS9facCX/Zuh/jFgyFDtxEqN9sk=",
+        "lastModified": 1639098768,
+        "narHash": "sha256-DZ4sG8FeDxWvBLixrj0jELXjtebZ0SCCPmQW43HNzIE=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "4ef9bd3a32316ce236164c7ebff00ebeb33236e2",
+        "rev": "c7b123af6b0b9b364cab03363504d42dca16a4b5",
         "type": "github"
       },
       "original": {
@@ -3412,11 +3600,11 @@
     "hackage_5": {
       "flake": false,
       "locked": {
-        "lastModified": 1639098768,
-        "narHash": "sha256-DZ4sG8FeDxWvBLixrj0jELXjtebZ0SCCPmQW43HNzIE=",
+        "lastModified": 1643073363,
+        "narHash": "sha256-66oSXQKEDIOSQ2uKAS9facCX/Zuh/jFgyFDtxEqN9sk=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c7b123af6b0b9b364cab03363504d42dca16a4b5",
+        "rev": "4ef9bd3a32316ce236164c7ebff00ebeb33236e2",
         "type": "github"
       },
       "original": {
@@ -3567,7 +3755,7 @@
         "hpc-coveralls": "hpc-coveralls",
         "nix-tools": "nix-tools",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "apropos",
           "haskell-nix",
           "nixpkgs-2105"
@@ -3596,12 +3784,12 @@
     "haskell-nix-extra-hackage": {
       "inputs": {
         "haskell-nix": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "plutarch",
           "haskell-nix"
         ],
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "plutarch",
           "nixpkgs"
         ]
@@ -3623,30 +3811,30 @@
     },
     "haskell-nix_2": {
       "inputs": {
-        "HTTP": "HTTP_7",
-        "cabal-32": "cabal-32_7",
-        "cabal-34": "cabal-34_7",
-        "cabal-36": "cabal-36_6",
-        "cardano-shell": "cardano-shell_7",
-        "flake-utils": "flake-utils_8",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_7",
+        "HTTP": "HTTP_8",
+        "cabal-32": "cabal-32_8",
+        "cabal-34": "cabal-34_8",
+        "cabal-36": "cabal-36_7",
+        "cardano-shell": "cardano-shell_8",
+        "flake-utils": "flake-utils_9",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_8",
         "hackage": "hackage_7",
-        "hpc-coveralls": "hpc-coveralls_7",
-        "hydra": "hydra_2",
-        "nix-tools": "nix-tools_7",
+        "hpc-coveralls": "hpc-coveralls_8",
+        "hydra": "hydra_3",
+        "nix-tools": "nix-tools_8",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "bot-plutus-interface",
           "haskell-nix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_7",
-        "nixpkgs-2105": "nixpkgs-2105_7",
-        "nixpkgs-2111": "nixpkgs-2111_7",
-        "nixpkgs-unstable": "nixpkgs-unstable_7",
-        "old-ghc-nix": "old-ghc-nix_7",
-        "stackage": "stackage_7"
+        "nixpkgs-2003": "nixpkgs-2003_8",
+        "nixpkgs-2105": "nixpkgs-2105_8",
+        "nixpkgs-2111": "nixpkgs-2111_8",
+        "nixpkgs-unstable": "nixpkgs-unstable_8",
+        "old-ghc-nix": "old-ghc-nix_8",
+        "stackage": "stackage_8"
       },
       "locked": {
         "lastModified": 1653486569,
@@ -3664,29 +3852,29 @@
     },
     "haskell-nix_3": {
       "inputs": {
-        "HTTP": "HTTP_9",
-        "cabal-32": "cabal-32_9",
-        "cabal-34": "cabal-34_9",
-        "cabal-36": "cabal-36_8",
-        "cardano-shell": "cardano-shell_9",
-        "flake-utils": "flake-utils_14",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_9",
+        "HTTP": "HTTP_10",
+        "cabal-32": "cabal-32_10",
+        "cabal-34": "cabal-34_10",
+        "cabal-36": "cabal-36_9",
+        "cardano-shell": "cardano-shell_10",
+        "flake-utils": "flake-utils_15",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_10",
         "hackage": "hackage_9",
-        "hpc-coveralls": "hpc-coveralls_9",
-        "hydra": "hydra_4",
-        "nix-tools": "nix-tools_9",
+        "hpc-coveralls": "hpc-coveralls_10",
+        "hydra": "hydra_5",
+        "nix-tools": "nix-tools_10",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "haskell-nix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_9",
-        "nixpkgs-2105": "nixpkgs-2105_9",
-        "nixpkgs-2111": "nixpkgs-2111_9",
+        "nixpkgs-2003": "nixpkgs-2003_10",
+        "nixpkgs-2105": "nixpkgs-2105_10",
+        "nixpkgs-2111": "nixpkgs-2111_10",
         "nixpkgs-2205": "nixpkgs-2205",
-        "nixpkgs-unstable": "nixpkgs-unstable_9",
-        "old-ghc-nix": "old-ghc-nix_9",
-        "stackage": "stackage_9"
+        "nixpkgs-unstable": "nixpkgs-unstable_10",
+        "old-ghc-nix": "old-ghc-nix_10",
+        "stackage": "stackage_10"
       },
       "locked": {
         "lastModified": 1660133415,
@@ -3704,29 +3892,29 @@
     },
     "haskell-nix_4": {
       "inputs": {
-        "HTTP": "HTTP_10",
-        "cabal-32": "cabal-32_10",
-        "cabal-34": "cabal-34_10",
-        "cabal-36": "cabal-36_9",
-        "cardano-shell": "cardano-shell_10",
-        "flake-utils": "flake-utils_18",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_10",
+        "HTTP": "HTTP_11",
+        "cabal-32": "cabal-32_11",
+        "cabal-34": "cabal-34_11",
+        "cabal-36": "cabal-36_10",
+        "cardano-shell": "cardano-shell_11",
+        "flake-utils": "flake-utils_19",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_11",
         "hackage": "hackage_10",
-        "hpc-coveralls": "hpc-coveralls_10",
-        "hydra": "hydra_5",
-        "nix-tools": "nix-tools_10",
+        "hpc-coveralls": "hpc-coveralls_11",
+        "hydra": "hydra_6",
+        "nix-tools": "nix-tools_11",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "plutarch",
           "haskell-nix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_10",
-        "nixpkgs-2105": "nixpkgs-2105_10",
-        "nixpkgs-2111": "nixpkgs-2111_10",
-        "nixpkgs-unstable": "nixpkgs-unstable_10",
-        "old-ghc-nix": "old-ghc-nix_10",
-        "stackage": "stackage_10"
+        "nixpkgs-2003": "nixpkgs-2003_11",
+        "nixpkgs-2105": "nixpkgs-2105_11",
+        "nixpkgs-2111": "nixpkgs-2111_11",
+        "nixpkgs-unstable": "nixpkgs-unstable_11",
+        "old-ghc-nix": "old-ghc-nix_11",
+        "stackage": "stackage_11"
       },
       "locked": {
         "lastModified": 1654068838,
@@ -3783,11 +3971,16 @@
         "cardano-shell": "cardano-shell_2",
         "flake-utils": "flake-utils_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
-        "hackage": "hackage_2",
+        "hackage": [
+          "hello-cardano-template",
+          "cardano-node",
+          "hackageNix"
+        ],
         "hpc-coveralls": "hpc-coveralls_2",
+        "hydra": "hydra",
         "nix-tools": "nix-tools_2",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
           "nixpkgs"
         ],
@@ -3799,11 +3992,11 @@
         "stackage": "stackage_2"
       },
       "locked": {
-        "lastModified": 1643073543,
-        "narHash": "sha256-g2l/KDWzMRTFRugNVcx3CPZeyA5BNcH9/zDiqFpprB4=",
+        "lastModified": 1649639788,
+        "narHash": "sha256-nBzRclDcVCEwrIMOYTNOZltd0bUhSyTk0c3UIrjqFhI=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
+        "rev": "fd74389bcf72b419f25cb6fe81c951b02ede4985",
         "type": "github"
       },
       "original": {
@@ -3821,14 +4014,13 @@
         "cardano-shell": "cardano-shell_3",
         "flake-utils": "flake-utils_3",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_3",
-        "hackage": "hackage_3",
+        "hackage": "hackage_2",
         "hpc-coveralls": "hpc-coveralls_3",
         "nix-tools": "nix-tools_3",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_3",
@@ -3861,14 +4053,13 @@
         "cardano-shell": "cardano-shell_4",
         "flake-utils": "flake-utils_4",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_4",
-        "hackage": "hackage_4",
+        "hackage": "hackage_3",
         "hpc-coveralls": "hpc-coveralls_4",
         "nix-tools": "nix-tools_4",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "membench",
           "cardano-node-snapshot",
           "nixpkgs"
@@ -3902,14 +4093,13 @@
         "cardano-shell": "cardano-shell_5",
         "flake-utils": "flake-utils_5",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_5",
-        "hackage": "hackage_5",
+        "hackage": "hackage_4",
         "hpc-coveralls": "hpc-coveralls_5",
         "nix-tools": "nix-tools_5",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "plutus-example",
           "nixpkgs"
         ],
@@ -3941,15 +4131,14 @@
         "cabal-34": "cabal-34_6",
         "cabal-36": "cabal-36_5",
         "cardano-shell": "cardano-shell_6",
-        "flake-utils": "flake-utils_7",
+        "flake-utils": "flake-utils_6",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_6",
-        "hackage": "hackage_6",
+        "hackage": "hackage_5",
         "hpc-coveralls": "hpc-coveralls_6",
-        "hydra": "hydra",
         "nix-tools": "nix-tools_6",
         "nixpkgs": [
-          "cardano-app-template",
-          "cardano-ogmios",
+          "hello-cardano-template",
+          "cardano-node-workbench",
           "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003_6",
@@ -3958,6 +4147,45 @@
         "nixpkgs-unstable": "nixpkgs-unstable_6",
         "old-ghc-nix": "old-ghc-nix_6",
         "stackage": "stackage_6"
+      },
+      "locked": {
+        "lastModified": 1643073543,
+        "narHash": "sha256-g2l/KDWzMRTFRugNVcx3CPZeyA5BNcH9/zDiqFpprB4=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix_6": {
+      "inputs": {
+        "HTTP": "HTTP_7",
+        "cabal-32": "cabal-32_7",
+        "cabal-34": "cabal-34_7",
+        "cabal-36": "cabal-36_6",
+        "cardano-shell": "cardano-shell_7",
+        "flake-utils": "flake-utils_8",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_7",
+        "hackage": "hackage_6",
+        "hpc-coveralls": "hpc-coveralls_7",
+        "hydra": "hydra_2",
+        "nix-tools": "nix-tools_7",
+        "nixpkgs": [
+          "hello-cardano-template",
+          "cardano-ogmios",
+          "nixpkgs"
+        ],
+        "nixpkgs-2003": "nixpkgs-2003_7",
+        "nixpkgs-2105": "nixpkgs-2105_7",
+        "nixpkgs-2111": "nixpkgs-2111_7",
+        "nixpkgs-unstable": "nixpkgs-unstable_7",
+        "old-ghc-nix": "old-ghc-nix_7",
+        "stackage": "stackage_7"
       },
       "locked": {
         "lastModified": 1655687787,
@@ -3973,31 +4201,31 @@
         "type": "github"
       }
     },
-    "haskellNix_6": {
+    "haskellNix_7": {
       "inputs": {
-        "HTTP": "HTTP_8",
-        "cabal-32": "cabal-32_8",
-        "cabal-34": "cabal-34_8",
-        "cabal-36": "cabal-36_7",
-        "cardano-shell": "cardano-shell_8",
-        "flake-utils": "flake-utils_13",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_8",
+        "HTTP": "HTTP_9",
+        "cabal-32": "cabal-32_9",
+        "cabal-34": "cabal-34_9",
+        "cabal-36": "cabal-36_8",
+        "cardano-shell": "cardano-shell_9",
+        "flake-utils": "flake-utils_14",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_9",
         "hackage": "hackage_8",
-        "hpc-coveralls": "hpc-coveralls_8",
-        "hydra": "hydra_3",
-        "nix-tools": "nix-tools_8",
+        "hpc-coveralls": "hpc-coveralls_9",
+        "hydra": "hydra_4",
+        "nix-tools": "nix-tools_9",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "cardano-wallet",
           "nixpkgs"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_8",
-        "nixpkgs-2105": "nixpkgs-2105_8",
-        "nixpkgs-2111": "nixpkgs-2111_8",
-        "nixpkgs-unstable": "nixpkgs-unstable_8",
-        "old-ghc-nix": "old-ghc-nix_8",
-        "stackage": "stackage_8"
+        "nixpkgs-2003": "nixpkgs-2003_9",
+        "nixpkgs-2105": "nixpkgs-2105_9",
+        "nixpkgs-2111": "nixpkgs-2111_9",
+        "nixpkgs-unstable": "nixpkgs-unstable_9",
+        "old-ghc-nix": "old-ghc-nix_9",
+        "stackage": "stackage_9"
       },
       "locked": {
         "lastModified": 1655369909,
@@ -4015,7 +4243,7 @@
     },
     "hci-effects": {
       "inputs": {
-        "nixpkgs": "nixpkgs_35"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1655158531,
@@ -4102,9 +4330,62 @@
         "type": "github"
       }
     },
+    "hello-cardano-template": {
+      "inputs": {
+        "apropos": "apropos",
+        "cardano-node": "cardano-node",
+        "cardano-node-workbench": "cardano-node-workbench",
+        "cardano-ogmios": "cardano-ogmios",
+        "cardano-transaction-lib": "cardano-transaction-lib",
+        "digraph": "digraph",
+        "dream2nix": "dream2nix",
+        "empty-flake": "empty-flake",
+        "flake-parts": "flake-parts_2",
+        "haskell-nix": "haskell-nix_3",
+        "jquery": "jquery",
+        "lighthouse-src": "lighthouse-src",
+        "lint-utils": "lint-utils",
+        "mlabs-ogmios": [
+          "hello-cardano-template",
+          "cardano-transaction-lib",
+          "ogmios"
+        ],
+        "nixpkgs": "nixpkgs_21",
+        "npmlock2nix": "npmlock2nix",
+        "ogmios-datum-cache": [
+          "hello-cardano-template",
+          "cardano-transaction-lib",
+          "ogmios-datum-cache"
+        ],
+        "plutarch": "plutarch",
+        "plutus": "plutus_4",
+        "ps-tools": [
+          "hello-cardano-template",
+          "purs-nix",
+          "ps-tools"
+        ],
+        "purs-nix": "purs-nix",
+        "treefmt-flake": "treefmt-flake",
+        "yubihsm": "yubihsm"
+      },
+      "locked": {
+        "lastModified": 1666819571,
+        "narHash": "sha256-0P0bnbGjdptv83QLnyng2nWM9aajyhNDU3gEyyx54XU=",
+        "owner": "ArdanaLabs",
+        "repo": "hello-cardano-template",
+        "rev": "d79c8c918489b28b5c86564664019b8c1a933b28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ArdanaLabs",
+        "ref": "hello-world-nixos-module",
+        "repo": "hello-cardano-template",
+        "type": "github"
+      }
+    },
     "hercules-ci-effects": {
       "inputs": {
-        "nixpkgs": "nixpkgs_20"
+        "nixpkgs": "nixpkgs_25"
       },
       "locked": {
         "lastModified": 1653841712,
@@ -4171,6 +4452,22 @@
       }
     },
     "hpc-coveralls_10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_11": {
       "flake": false,
       "locked": {
         "lastModified": 1607498076,
@@ -4335,8 +4632,8 @@
       "inputs": {
         "nix": "nix",
         "nixpkgs": [
-          "cardano-app-template",
-          "cardano-ogmios",
+          "hello-cardano-template",
+          "cardano-node",
           "haskellNix",
           "hydra",
           "nix",
@@ -4360,10 +4657,9 @@
       "inputs": {
         "nix": "nix_2",
         "nixpkgs": [
-          "cardano-app-template",
-          "cardano-transaction-lib",
-          "bot-plutus-interface",
-          "haskell-nix",
+          "hello-cardano-template",
+          "cardano-ogmios",
+          "haskellNix",
           "hydra",
           "nix",
           "nixpkgs"
@@ -4386,10 +4682,10 @@
       "inputs": {
         "nix": "nix_3",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
-          "cardano-wallet",
-          "haskellNix",
+          "bot-plutus-interface",
+          "haskell-nix",
           "hydra",
           "nix",
           "nixpkgs"
@@ -4412,8 +4708,10 @@
       "inputs": {
         "nix": "nix_4",
         "nixpkgs": [
-          "cardano-app-template",
-          "haskell-nix",
+          "hello-cardano-template",
+          "cardano-transaction-lib",
+          "cardano-wallet",
+          "haskellNix",
           "hydra",
           "nix",
           "nixpkgs"
@@ -4436,7 +4734,31 @@
       "inputs": {
         "nix": "nix_5",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
+          "haskell-nix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1646878427,
+        "narHash": "sha256-KtbrofMtN8GlM7D+n90kixr7QpSlVmdN+vK5CA/aRzc=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "28b682b85b7efc5cf7974065792a1f22203a5927",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
+      }
+    },
+    "hydra_6": {
+      "inputs": {
+        "nix": "nix_6",
+        "nixpkgs": [
+          "hello-cardano-template",
           "plutarch",
           "haskell-nix",
           "hydra",
@@ -4560,7 +4882,7 @@
     },
     "iohk-nix_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_12"
+        "nixpkgs": "nixpkgs_17"
       },
       "locked": {
         "lastModified": 1658222743,
@@ -4578,7 +4900,7 @@
     },
     "iohk-nix_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_13"
+        "nixpkgs": "nixpkgs_18"
       },
       "locked": {
         "lastModified": 1649070135,
@@ -4646,17 +4968,17 @@
     "iohkNix": {
       "inputs": {
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1631778944,
-        "narHash": "sha256-N5eCcUYtZ5kUOl/JJGjx6ZzhA3uIn1itDRTiRV+3jLw=",
+        "lastModified": 1653579289,
+        "narHash": "sha256-wveDdPsgB/3nAGAdFaxrcgLEpdi0aJ5kEVNtI+YqVfo=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "db2c75a09c696271194bb3ef25ec8e9839b594b7",
+        "rev": "edb2d2df2ebe42bbdf03a0711115cf6213c9d366",
         "type": "github"
       },
       "original": {
@@ -4668,10 +4990,9 @@
     "iohkNix_2": {
       "inputs": {
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "nixpkgs"
         ]
       },
@@ -4692,10 +5013,9 @@
     "iohkNix_3": {
       "inputs": {
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "membench",
           "cardano-node-snapshot",
           "nixpkgs"
@@ -4718,10 +5038,9 @@
     "iohkNix_4": {
       "inputs": {
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "plutus-example",
           "nixpkgs"
         ]
@@ -4743,7 +5062,29 @@
     "iohkNix_5": {
       "inputs": {
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
+          "cardano-node-workbench",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1645693195,
+        "narHash": "sha256-UDemE2MFEi/L8Xmwi1/FuKU9ka3QqDye6k7rVW6ryeE=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "29c9a3b6704b5c0df3bb4a3e65240749883c50a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iohkNix_6": {
+      "inputs": {
+        "nixpkgs": [
+          "hello-cardano-template",
           "cardano-ogmios",
           "nixpkgs"
         ]
@@ -4762,10 +5103,10 @@
         "type": "github"
       }
     },
-    "iohkNix_6": {
+    "iohkNix_7": {
       "inputs": {
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "cardano-wallet",
           "nixpkgs"
@@ -4837,9 +5178,9 @@
     },
     "lint-utils": {
       "inputs": {
-        "flake-utils": "flake-utils_15",
+        "flake-utils": "flake-utils_16",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "nixpkgs"
         ]
       },
@@ -4938,6 +5279,22 @@
         "type": "github"
       }
     },
+    "lowdown-src_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
     "mach-nix": {
       "flake": false,
       "locked": {
@@ -5002,22 +5359,25 @@
     },
     "membench": {
       "inputs": {
-        "cardano-mainnet-mirror": "cardano-mainnet-mirror",
+        "cardano-mainnet-mirror": "cardano-mainnet-mirror_2",
         "cardano-node-measured": [
-          "cardano-app-template",
-          "cardano-node"
+          "hello-cardano-template",
+          "cardano-node",
+          "node-snapshot"
         ],
         "cardano-node-process": [
-          "cardano-app-template",
-          "cardano-node"
+          "hello-cardano-template",
+          "cardano-node",
+          "node-snapshot"
         ],
         "cardano-node-snapshot": "cardano-node-snapshot",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
+          "node-snapshot",
           "nixpkgs"
         ],
-        "ouroboros-network": "ouroboros-network_3"
+        "ouroboros-network": "ouroboros-network_2"
       },
       "locked": {
         "lastModified": 1645070579,
@@ -5035,75 +5395,32 @@
     },
     "membench_2": {
       "inputs": {
-        "cardano-mainnet-mirror": "cardano-mainnet-mirror_2",
-        "cardano-node-measured": [
-          "cardano-app-template",
-          "cardano-node",
-          "membench",
-          "cardano-node-snapshot"
-        ],
-        "cardano-node-process": [
-          "cardano-app-template",
-          "cardano-node",
-          "membench",
-          "cardano-node-snapshot"
-        ],
-        "cardano-node-snapshot": "cardano-node-snapshot_2",
-        "nixpkgs": [
-          "cardano-app-template",
-          "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
-          "nixpkgs"
-        ],
-        "ouroboros-network": "ouroboros-network_2"
-      },
-      "locked": {
-        "lastModified": 1644547122,
-        "narHash": "sha256-8nWK+ScMACvRQLbA27gwXNoZver+Wx/cF7V37044koY=",
-        "owner": "input-output-hk",
-        "repo": "cardano-memory-benchmark",
-        "rev": "9d8ff4b9394de0421ee95caa511d01163de88b77",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-memory-benchmark",
-        "type": "github"
-      }
-    },
-    "membench_3": {
-      "inputs": {
         "cardano-mainnet-mirror": "cardano-mainnet-mirror_3",
         "cardano-node-measured": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "membench",
           "cardano-node-snapshot"
         ],
         "cardano-node-process": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "membench",
           "cardano-node-snapshot"
         ],
         "cardano-node-snapshot": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "membench",
           "cardano-node-snapshot"
         ],
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "membench",
           "cardano-node-snapshot",
           "nixpkgs"
@@ -5126,7 +5443,7 @@
     },
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs_24"
+        "nixpkgs": "nixpkgs_29"
       },
       "locked": {
         "lastModified": 1655042882,
@@ -5144,7 +5461,7 @@
     },
     "naersk_2": {
       "inputs": {
-        "nixpkgs": "nixpkgs_28"
+        "nixpkgs": "nixpkgs_33"
       },
       "locked": {
         "lastModified": 1655042882,
@@ -5165,7 +5482,7 @@
         "devshell": "devshell_2",
         "dream2nix": "dream2nix_2",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "yubihsm",
           "nixpkgs"
         ],
@@ -5188,7 +5505,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -5225,6 +5542,22 @@
     "nix-tools_10": {
       "flake": false,
       "locked": {
+        "lastModified": 1659569011,
+        "narHash": "sha256-wHS0H5+TERmDnPCfzH4A+rSR5TvjYMWus9BNeNAMyUM=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "555d57e1ea81b79945f2608aa261df20f6b602a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nix-tools_11": {
+      "flake": false,
+      "locked": {
         "lastModified": 1649424170,
         "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
         "owner": "input-output-hk",
@@ -5241,11 +5574,11 @@
     "nix-tools_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1636018067,
-        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
+        "lastModified": 1649424170,
+        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
+        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
         "type": "github"
       },
       "original": {
@@ -5305,11 +5638,11 @@
     "nix-tools_6": {
       "flake": false,
       "locked": {
-        "lastModified": 1649424170,
-        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
+        "lastModified": 1636018067,
+        "narHash": "sha256-ng306fkuwr6V/malWtt3979iAC4yMVDDH2ViwYB6sQE=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
+        "rev": "ed5bd7215292deba55d6ab7a4e8c21f8b1564dda",
         "type": "github"
       },
       "original": {
@@ -5353,11 +5686,27 @@
     "nix-tools_9": {
       "flake": false,
       "locked": {
-        "lastModified": 1659569011,
-        "narHash": "sha256-wHS0H5+TERmDnPCfzH4A+rSR5TvjYMWus9BNeNAMyUM=",
+        "lastModified": 1649424170,
+        "narHash": "sha256-XgKXWispvv5RCvZzPb+p7e6Hy3LMuRjafKMl7kXzxGw=",
         "owner": "input-output-hk",
         "repo": "nix-tools",
-        "rev": "555d57e1ea81b79945f2608aa261df20f6b602a5",
+        "rev": "e109c94016e3b6e0db7ed413c793e2d4bdb24aa7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "type": "github"
+      }
+    },
+    "nixTools": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1644395812,
+        "narHash": "sha256-BVFk/BEsTLq5MMZvdy3ZYHKfaS3dHrsKh4+tb5t5b58=",
+        "owner": "input-output-hk",
+        "repo": "nix-tools",
+        "rev": "d847c63b99bbec78bf83be2a61dc9f09b8a9ccc1",
         "type": "github"
       },
       "original": {
@@ -5369,7 +5718,7 @@
     "nix_2": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_9",
         "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
@@ -5390,7 +5739,7 @@
     "nix_3": {
       "inputs": {
         "lowdown-src": "lowdown-src_3",
-        "nixpkgs": "nixpkgs_11",
+        "nixpkgs": "nixpkgs_10",
         "nixpkgs-regression": "nixpkgs-regression_3"
       },
       "locked": {
@@ -5411,7 +5760,7 @@
     "nix_4": {
       "inputs": {
         "lowdown-src": "lowdown-src_4",
-        "nixpkgs": "nixpkgs_15",
+        "nixpkgs": "nixpkgs_16",
         "nixpkgs-regression": "nixpkgs-regression_4"
       },
       "locked": {
@@ -5432,8 +5781,29 @@
     "nix_5": {
       "inputs": {
         "lowdown-src": "lowdown-src_5",
-        "nixpkgs": "nixpkgs_19",
+        "nixpkgs": "nixpkgs_20",
         "nixpkgs-regression": "nixpkgs-regression_5"
+      },
+      "locked": {
+        "lastModified": 1643066034,
+        "narHash": "sha256-xEPeMcNJVOeZtoN+d+aRwolpW8mFSEQx76HTRdlhPhg=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "a1cd7e58606a41fcf62bf8637804cf8306f17f62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.6.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix_6": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_6",
+        "nixpkgs": "nixpkgs_24",
+        "nixpkgs-regression": "nixpkgs-regression_6"
       },
       "locked": {
         "lastModified": 1643066034,
@@ -5472,16 +5842,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "lastModified": 1647297614,
+        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-2003": {
@@ -5501,6 +5873,22 @@
       }
     },
     "nixpkgs-2003_10": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003_11": {
       "locked": {
         "lastModified": 1620055814,
         "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
@@ -5662,6 +6050,22 @@
     },
     "nixpkgs-2105_10": {
       "locked": {
+        "lastModified": 1655034179,
+        "narHash": "sha256-rf1/7AbzuYDw6+8Xvvf3PtEOygymLBrFsFxvext5ZjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "046ee4af7a9f016a364f8f78eeaa356ba524ac31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105_11": {
+      "locked": {
         "lastModified": 1645296114,
         "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
         "owner": "NixOS",
@@ -5678,11 +6082,11 @@
     },
     "nixpkgs-2105_2": {
       "locked": {
-        "lastModified": 1640283157,
-        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
+        "lastModified": 1645296114,
+        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
+        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
         "type": "github"
       },
       "original": {
@@ -5742,11 +6146,11 @@
     },
     "nixpkgs-2105_6": {
       "locked": {
-        "lastModified": 1645296114,
-        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
+        "lastModified": 1640283157,
+        "narHash": "sha256-6Ddfop+rKE+Gl9Tjp9YIrkfoYPzb8F80ergdjcq3/MY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
+        "rev": "dde1557825c5644c869c5efc7448dc03722a8f09",
         "type": "github"
       },
       "original": {
@@ -5790,11 +6194,11 @@
     },
     "nixpkgs-2105_9": {
       "locked": {
-        "lastModified": 1655034179,
-        "narHash": "sha256-rf1/7AbzuYDw6+8Xvvf3PtEOygymLBrFsFxvext5ZjI=",
+        "lastModified": 1645296114,
+        "narHash": "sha256-y53N7TyIkXsjMpOG7RhvqJFGDacLs9HlyHeSTBioqYU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "046ee4af7a9f016a364f8f78eeaa356ba524ac31",
+        "rev": "530a53dcbc9437363471167a5e4762c5fcfa34a1",
         "type": "github"
       },
       "original": {
@@ -5822,6 +6226,22 @@
     },
     "nixpkgs-2111_10": {
       "locked": {
+        "lastModified": 1656782578,
+        "narHash": "sha256-1eMCBEqJplPotTo/SZ/t5HU6Sf2I8qKlZi9MX7jv9fw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "573603b7fdb9feb0eb8efc16ee18a015c667ab1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111_11": {
+      "locked": {
         "lastModified": 1648744337,
         "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
         "owner": "NixOS",
@@ -5838,11 +6258,11 @@
     },
     "nixpkgs-2111_2": {
       "locked": {
-        "lastModified": 1640283207,
-        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
+        "lastModified": 1648744337,
+        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
+        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
         "type": "github"
       },
       "original": {
@@ -5902,11 +6322,11 @@
     },
     "nixpkgs-2111_6": {
       "locked": {
-        "lastModified": 1648744337,
-        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
+        "lastModified": 1640283207,
+        "narHash": "sha256-SCwl7ZnCfMDsuSYvwIroiAlk7n33bW8HFfY8NvKhcPA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
+        "rev": "64c7e3388bbd9206e437713351e814366e0c3284",
         "type": "github"
       },
       "original": {
@@ -5950,11 +6370,11 @@
     },
     "nixpkgs-2111_9": {
       "locked": {
-        "lastModified": 1656782578,
-        "narHash": "sha256-1eMCBEqJplPotTo/SZ/t5HU6Sf2I8qKlZi9MX7jv9fw=",
+        "lastModified": 1648744337,
+        "narHash": "sha256-bYe1dFJAXovjqiaPKrmAbSBEK5KUkgwVaZcTbSoJ7hg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "573603b7fdb9feb0eb8efc16ee18a015c667ab1b",
+        "rev": "0a58eebd8ec65ffdef2ce9562784123a73922052",
         "type": "github"
       },
       "original": {
@@ -6087,6 +6507,21 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-regression_6": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "indirect"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1644486793,
@@ -6105,6 +6540,22 @@
     },
     "nixpkgs-unstable_10": {
       "locked": {
+        "lastModified": 1657888067,
+        "narHash": "sha256-GnwJoFBTPfW3+mz7QEeJEEQ9OMHZOiIJ/qDhZxrlKh8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "65fae659e31098ca4ac825a6fef26d890aaf3f4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_11": {
+      "locked": {
         "lastModified": 1648219316,
         "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
         "owner": "NixOS",
@@ -6121,11 +6572,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1641285291,
-        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
         "type": "github"
       },
       "original": {
@@ -6185,11 +6636,11 @@
     },
     "nixpkgs-unstable_6": {
       "locked": {
-        "lastModified": 1648219316,
-        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
+        "lastModified": 1641285291,
+        "narHash": "sha256-KYaOBNGar3XWTxTsYPr9P6u74KAqNq0wobEC236U+0c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
+        "rev": "0432195a4b8d68faaa7d3d4b355260a3120aeeae",
         "type": "github"
       },
       "original": {
@@ -6233,11 +6684,11 @@
     },
     "nixpkgs-unstable_9": {
       "locked": {
-        "lastModified": 1657888067,
-        "narHash": "sha256-GnwJoFBTPfW3+mz7QEeJEEQ9OMHZOiIJ/qDhZxrlKh8=",
+        "lastModified": 1648219316,
+        "narHash": "sha256-Ctij+dOi0ZZIfX5eMhgwugfvB+WZSrvVNAyAuANOsnQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "65fae659e31098ca4ac825a6fef26d890aaf3f4e",
+        "rev": "30d3d79b7d3607d56546dd2a6b49e156ba0ec634",
         "type": "github"
       },
       "original": {
@@ -6248,20 +6699,6 @@
       }
     },
     "nixpkgs_10": {
-      "locked": {
-        "lastModified": 1656401090,
-        "narHash": "sha256-bUS2nfQsvTQW2z8SK7oEFSElbmoBahOPtbXPm0AL3I4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "16de63fcc54e88b9a106a603038dd5dd2feb21eb",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_11": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -6276,7 +6713,96 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1646470760,
+        "narHash": "sha256-dQISyucVCCPaFioUhy5ZgfBz8rOMKGI8k13aPDFTqEs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1fc7212a2c3992eedc6eedf498955c321ad81cc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1fc7212a2c3992eedc6eedf498955c321ad81cc2",
+        "type": "github"
+      }
+    },
     "nixpkgs_12": {
+      "locked": {
+        "lastModified": 1619531122,
+        "narHash": "sha256-ovm5bo6PkZzNKh2YGXbRKYIjega0EjiEP0YDwyeXEYU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bb80d578e8ad3cb5a607f468ac00cc546d0396dc",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_13": {
+      "locked": {
+        "lastModified": 1656461576,
+        "narHash": "sha256-rlmmw6lIlkMQIiB+NsnO8wQYWTfle8TA41UREPLP5VY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cf3ab54b4afe2b7477faa1dd0b65bf74c055d70c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_14": {
+      "locked": {
+        "lastModified": 1655567057,
+        "narHash": "sha256-Cc5hQSMsTzOHmZnYm8OSJ5RNUp22bd5NADWLHorULWQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e0a42267f73ea52adc061a64650fddc59906fc99",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_15": {
+      "locked": {
+        "lastModified": 1656401090,
+        "narHash": "sha256-bUS2nfQsvTQW2z8SK7oEFSElbmoBahOPtbXPm0AL3I4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "16de63fcc54e88b9a106a603038dd5dd2feb21eb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_16": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_17": {
       "locked": {
         "lastModified": 0,
         "narHash": "sha256-cowVkScfUPlbBXUp08MeVk/wgm9E1zp1uC+9no2hZYw=",
@@ -6288,7 +6814,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_13": {
+    "nixpkgs_18": {
       "locked": {
         "lastModified": 1657888067,
         "narHash": "sha256-GnwJoFBTPfW3+mz7QEeJEEQ9OMHZOiIJ/qDhZxrlKh8=",
@@ -6302,7 +6828,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_14": {
+    "nixpkgs_19": {
       "locked": {
         "lastModified": 1634172192,
         "narHash": "sha256-FBF4U/T+bMg4sEyT/zkgasvVquGzgdAf4y8uCosKMmo=",
@@ -6318,7 +6844,23 @@
         "type": "github"
       }
     },
-    "nixpkgs_15": {
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-21.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_20": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -6333,7 +6875,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_16": {
+    "nixpkgs_21": {
       "locked": {
         "lastModified": 1659981942,
         "narHash": "sha256-uCFiP/B/NXOWzhN6TKfMbSxtVMk1bVnCrnJRjCF6RmU=",
@@ -6349,7 +6891,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_17": {
+    "nixpkgs_22": {
       "locked": {
         "lastModified": 1652885393,
         "narHash": "sha256-YIgvvlk4iQ1Hi7KD9o5gsojc+ApB+jiH1d5stK8uXiw=",
@@ -6365,7 +6907,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_18": {
+    "nixpkgs_23": {
       "locked": {
         "lastModified": 1653117584,
         "narHash": "sha256-5uUrHeHBIaySBTrRExcCoW8fBBYVSDjDYDU5A6iOl+k=",
@@ -6379,7 +6921,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_19": {
+    "nixpkgs_24": {
       "locked": {
         "lastModified": 1632864508,
         "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
@@ -6394,21 +6936,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_20": {
+    "nixpkgs_25": {
       "locked": {
         "lastModified": 1647297614,
         "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
@@ -6424,7 +6952,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_21": {
+    "nixpkgs_26": {
       "flake": false,
       "locked": {
         "lastModified": 1645493675,
@@ -6441,7 +6969,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_22": {
+    "nixpkgs_27": {
       "flake": false,
       "locked": {
         "lastModified": 1660227034,
@@ -6458,94 +6986,20 @@
         "type": "github"
       }
     },
-    "nixpkgs_23": {
-      "locked": {
-        "lastModified": 1655400192,
-        "narHash": "sha256-49OBVVRgb9H/PSmNT9W61+NRdDbuSJVuDDflwXlaUKU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3d7435c638baffaa826b85459df0fff47f12317d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_24": {
-      "locked": {
-        "lastModified": 1655481042,
-        "narHash": "sha256-XHbcywq2vIQ5CeH1OK3TN793jkiNAAZsSctS1PFgseo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "103a4c0ae46afa9cf008c30744175315ca38e9f9",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_25": {
-      "locked": {
-        "lastModified": 1655481042,
-        "narHash": "sha256-XHbcywq2vIQ5CeH1OK3TN793jkiNAAZsSctS1PFgseo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "103a4c0ae46afa9cf008c30744175315ca38e9f9",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_26": {
-      "locked": {
-        "lastModified": 1646506091,
-        "narHash": "sha256-sWNAJE2m+HOh1jtXlHcnhxsj6/sXrHgbqVNcVRlveK4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3e644bd62489b516292c816f70bf0052c693b3c7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_27": {
-      "locked": {
-        "lastModified": 1655400192,
-        "narHash": "sha256-49OBVVRgb9H/PSmNT9W61+NRdDbuSJVuDDflwXlaUKU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3d7435c638baffaa826b85459df0fff47f12317d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_28": {
       "locked": {
-        "lastModified": 1655481042,
-        "narHash": "sha256-XHbcywq2vIQ5CeH1OK3TN793jkiNAAZsSctS1PFgseo=",
-        "owner": "NixOS",
+        "lastModified": 1655400192,
+        "narHash": "sha256-49OBVVRgb9H/PSmNT9W61+NRdDbuSJVuDDflwXlaUKU=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "103a4c0ae46afa9cf008c30744175315ca38e9f9",
+        "rev": "3d7435c638baffaa826b85459df0fff47f12317d",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_29": {
@@ -6564,11 +7018,27 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1642336556,
-        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
+        "lastModified": 1639161226,
+        "narHash": "sha256-75Y08ynJDTq6HHGIF+8IADBJSVip0UyWQH7jqSFnRR8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "573095944e7c1d58d30fc679c81af63668b54056",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-21.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_30": {
+      "locked": {
+        "lastModified": 1655481042,
+        "narHash": "sha256-XHbcywq2vIQ5CeH1OK3TN793jkiNAAZsSctS1PFgseo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
+        "rev": "103a4c0ae46afa9cf008c30744175315ca38e9f9",
         "type": "github"
       },
       "original": {
@@ -6576,39 +7046,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_30": {
-      "locked": {
-        "lastModified": 1656549732,
-        "narHash": "sha256-eILutFZGjfk2bEzfim8S/qyYc//0S1KsCeO+OWbtoR0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d3248619647234b5dc74a6921bcdf6dd8323eb22",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_31": {
-      "locked": {
-        "lastModified": 1645013224,
-        "narHash": "sha256-b7OEC8vwzJv3rsz9pwnTX2LQDkeOWz2DbKypkVvNHXc=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b66b39216b1fef2d8c33cc7a5c72d8da80b79970",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_32": {
       "locked": {
         "lastModified": 1646506091,
         "narHash": "sha256-sWNAJE2m+HOh1jtXlHcnhxsj6/sXrHgbqVNcVRlveK4=",
@@ -6624,7 +7062,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_33": {
+    "nixpkgs_32": {
       "locked": {
         "lastModified": 1655400192,
         "narHash": "sha256-49OBVVRgb9H/PSmNT9W61+NRdDbuSJVuDDflwXlaUKU=",
@@ -6640,7 +7078,99 @@
         "type": "github"
       }
     },
+    "nixpkgs_33": {
+      "locked": {
+        "lastModified": 1655481042,
+        "narHash": "sha256-XHbcywq2vIQ5CeH1OK3TN793jkiNAAZsSctS1PFgseo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "103a4c0ae46afa9cf008c30744175315ca38e9f9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
     "nixpkgs_34": {
+      "locked": {
+        "lastModified": 1655481042,
+        "narHash": "sha256-XHbcywq2vIQ5CeH1OK3TN793jkiNAAZsSctS1PFgseo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "103a4c0ae46afa9cf008c30744175315ca38e9f9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_35": {
+      "locked": {
+        "lastModified": 1656549732,
+        "narHash": "sha256-eILutFZGjfk2bEzfim8S/qyYc//0S1KsCeO+OWbtoR0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d3248619647234b5dc74a6921bcdf6dd8323eb22",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_36": {
+      "locked": {
+        "lastModified": 1645013224,
+        "narHash": "sha256-b7OEC8vwzJv3rsz9pwnTX2LQDkeOWz2DbKypkVvNHXc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b66b39216b1fef2d8c33cc7a5c72d8da80b79970",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_37": {
+      "locked": {
+        "lastModified": 1646506091,
+        "narHash": "sha256-sWNAJE2m+HOh1jtXlHcnhxsj6/sXrHgbqVNcVRlveK4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e644bd62489b516292c816f70bf0052c693b3c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_38": {
+      "locked": {
+        "lastModified": 1655400192,
+        "narHash": "sha256-49OBVVRgb9H/PSmNT9W61+NRdDbuSJVuDDflwXlaUKU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3d7435c638baffaa826b85459df0fff47f12317d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_39": {
       "locked": {
         "lastModified": 1664780719,
         "narHash": "sha256-Oxe6la5dSqRfJogjtY4sRzJjDDqvroJIVkcGEOT87MA=",
@@ -6656,55 +7186,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_35": {
-      "locked": {
-        "lastModified": 1647297614,
-        "narHash": "sha256-ulGq3W5XsrBMU/u5k9d4oPy65pQTkunR4HKKtTq0RwY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "73ad5f9e147c0d2a2061f1d4bd91e05078dc0b58",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_36": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-21.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_37": {
-      "locked": {
-        "lastModified": 1639161226,
-        "narHash": "sha256-75Y08ynJDTq6HHGIF+8IADBJSVip0UyWQH7jqSFnRR8=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "573095944e7c1d58d30fc679c81af63668b54056",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-21.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_38": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1638798756,
         "narHash": "sha256-VFuVwQ4YjPNnclRh6vcy5pR0AgPxlGeanVYBLVCr9ZI=",
@@ -6720,7 +7202,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_39": {
+    "nixpkgs_40": {
       "locked": {
         "lastModified": 1660496378,
         "narHash": "sha256-sgAhmrC1iSnl5T2VPPiMpciH1aRw5c7PYEdXX6jd6Gk=",
@@ -6736,59 +7218,42 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
-        "type": "indirect"
-      }
-    },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1632864508,
-        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-21.05-small",
         "type": "indirect"
       }
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1646470760,
-        "narHash": "sha256-dQISyucVCCPaFioUhy5ZgfBz8rOMKGI8k13aPDFTqEs=",
-        "owner": "nixos",
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1fc7212a2c3992eedc6eedf498955c321ad81cc2",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1fc7212a2c3992eedc6eedf498955c321ad81cc2",
-        "type": "github"
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
       }
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1619531122,
-        "narHash": "sha256-ovm5bo6PkZzNKh2YGXbRKYIjega0EjiEP0YDwyeXEYU=",
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb80d578e8ad3cb5a607f468ac00cc546d0396dc",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
         "type": "github"
       },
       "original": {
@@ -6798,32 +7263,78 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1656461576,
-        "narHash": "sha256-rlmmw6lIlkMQIiB+NsnO8wQYWTfle8TA41UREPLP5VY=",
+        "lastModified": 1642336556,
+        "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf3ab54b4afe2b7477faa1dd0b65bf74c055d70c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1655567057,
-        "narHash": "sha256-Cc5hQSMsTzOHmZnYm8OSJ5RNUp22bd5NADWLHorULWQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e0a42267f73ea52adc061a64650fddc59906fc99",
+        "rev": "f3d9d4bd898cca7d04af2ae4f6ef01f2219df3d6",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1632864508,
+        "narHash": "sha256-d127FIvGR41XbVRDPVvozUPQ/uRHbHwvfyKHwEt5xFM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "82891b5e2c2359d7e58d08849e4c89511ab94234",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-21.05-small",
+        "type": "indirect"
+      }
+    },
+    "node-process": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648681325,
+        "narHash": "sha256-6oWDYmMb+V4x0jCoYDzKfBJMpr7Mx5zA3WMpNHspuSw=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "78675fbf8986c87c0d2356b727a0ec2060f1adba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "type": "github"
+      }
+    },
+    "node-snapshot": {
+      "inputs": {
+        "customConfig": "customConfig_2",
+        "haskellNix": "haskellNix_2",
+        "iohkNix": "iohkNix_2",
+        "membench": "membench",
+        "nixpkgs": [
+          "hello-cardano-template",
+          "cardano-node",
+          "node-snapshot",
+          "haskellNix",
+          "nixpkgs-2105"
+        ],
+        "plutus-example": "plutus-example",
+        "utils": "utils_3"
+      },
+      "locked": {
+        "lastModified": 1645120669,
+        "narHash": "sha256-2MKfGsYS5n69+pfqNHb4IH/E95ok1MD7mhEYfUpRcz4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "7f00e3ea5a61609e19eeeee4af35241571efdf5c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-node",
+        "rev": "7f00e3ea5a61609e19eeeee4af35241571efdf5c",
+        "type": "github"
       }
     },
     "node2nix": {
@@ -6893,8 +7404,8 @@
     },
     "ogmios-datum-cache": {
       "inputs": {
-        "flake-compat": "flake-compat_7",
-        "nixpkgs": "nixpkgs_14",
+        "flake-compat": "flake-compat_9",
+        "nixpkgs": "nixpkgs_19",
         "unstable_nixpkgs": "unstable_nixpkgs"
       },
       "locked": {
@@ -6921,11 +7432,11 @@
         "cardano-node": "cardano-node_3",
         "cardano-prelude": "cardano-prelude_2",
         "ekg-json": "ekg-json_2",
-        "flake-compat": "flake-compat_6",
+        "flake-compat": "flake-compat_8",
         "flat": "flat_2",
         "goblins": "goblins_2",
         "haskell-nix": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "haskell-nix"
         ],
@@ -6936,12 +7447,12 @@
         "iohk-monitoring-framework": "iohk-monitoring-framework_2",
         "iohk-nix": "iohk-nix_3",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "nixpkgs"
         ],
         "optparse-applicative": "optparse-applicative_2",
-        "ouroboros-network": "ouroboros-network_5",
+        "ouroboros-network": "ouroboros-network_4",
         "plutus": "plutus_2",
         "typed-protocols": "typed-protocols_2",
         "wai-routes": "wai-routes"
@@ -6979,6 +7490,23 @@
       }
     },
     "old-ghc-nix_10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix_11": {
       "flake": false,
       "locked": {
         "lastModified": 1631092763,
@@ -7200,22 +7728,6 @@
     "ouroboros-network_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1643385024,
-        "narHash": "sha256-9R4Z1jBsTcEgBHxhzjCJnroEcdfMsTjf8kwg6uPue+Q=",
-        "owner": "input-output-hk",
-        "repo": "ouroboros-network",
-        "rev": "8e97076176d465f5f4f86d5b5596220272630649",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "ouroboros-network",
-        "type": "github"
-      }
-    },
-    "ouroboros-network_4": {
-      "flake": false,
-      "locked": {
         "lastModified": 1658339771,
         "narHash": "sha256-3ElbHM1B5u1QD0aes1KbaX2FxKJzU05H0OzJ36em1Bg=",
         "owner": "input-output-hk",
@@ -7230,7 +7742,7 @@
         "type": "github"
       }
     },
-    "ouroboros-network_5": {
+    "ouroboros-network_4": {
       "flake": false,
       "locked": {
         "lastModified": 1654820431,
@@ -7277,7 +7789,7 @@
         "hercules-ci-effects": "hercules-ci-effects",
         "iohk-nix": "iohk-nix_4",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "plutarch",
           "haskell-nix",
           "nixpkgs-unstable"
@@ -7304,25 +7816,25 @@
     "plutip": {
       "inputs": {
         "bot-plutus-interface": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "bot-plutus-interface"
         ],
-        "flake-compat": "flake-compat_8",
+        "flake-compat": "flake-compat_10",
         "haskell-nix": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "bot-plutus-interface",
           "haskell-nix"
         ],
         "iohk-nix": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "bot-plutus-interface",
           "iohk-nix"
         ],
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-transaction-lib",
           "bot-plutus-interface",
           "haskell-nix",
@@ -7364,6 +7876,38 @@
     "plutus-apps": {
       "flake": false,
       "locked": {
+        "lastModified": 1647347289,
+        "narHash": "sha256-dxKZ1Zvflyt6igYm39POV6X/0giKbfb4U7D1TvevQls=",
+        "owner": "input-output-hk",
+        "repo": "plutus-apps",
+        "rev": "2a40552f4654d695f21783c86e8ae59243ce9dfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "plutus-apps",
+        "type": "github"
+      }
+    },
+    "plutus-apps_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647347289,
+        "narHash": "sha256-dxKZ1Zvflyt6igYm39POV6X/0giKbfb4U7D1TvevQls=",
+        "owner": "input-output-hk",
+        "repo": "plutus-apps",
+        "rev": "2a40552f4654d695f21783c86e8ae59243ce9dfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "plutus-apps",
+        "type": "github"
+      }
+    },
+    "plutus-apps_3": {
+      "flake": false,
+      "locked": {
         "lastModified": 1661246964,
         "narHash": "sha256-NuSwD6mjUEgBay2sIKRo6DUBualMQUDKfHQlsbYzKuk=",
         "owner": "mlabs-haskell",
@@ -7384,10 +7928,9 @@
         "haskellNix": "haskellNix_4",
         "iohkNix": "iohkNix_4",
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "cardano-node",
-          "membench",
-          "cardano-node-snapshot",
+          "node-snapshot",
           "plutus-example",
           "haskellNix",
           "nixpkgs-2105"
@@ -7434,7 +7977,7 @@
         "haskell-language-server": "haskell-language-server_2",
         "haskell-nix": "haskell-nix_5",
         "iohk-nix": "iohk-nix_5",
-        "nixpkgs": "nixpkgs_21",
+        "nixpkgs": "nixpkgs_26",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
@@ -7460,7 +8003,7 @@
         "haskell-language-server": "haskell-language-server_3",
         "haskell-nix": "haskell-nix_6",
         "iohk-nix": "iohk-nix_6",
-        "nixpkgs": "nixpkgs_22",
+        "nixpkgs": "nixpkgs_27",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_2",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock_2"
       },
@@ -7514,8 +8057,8 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-utils": "flake-utils_10",
-        "nixpkgs": "nixpkgs_7"
+        "flake-utils": "flake-utils_11",
+        "nixpkgs": "nixpkgs_12"
       },
       "locked": {
         "lastModified": 1639823344,
@@ -7566,12 +8109,12 @@
     "pre-commit-hooks_2": {
       "inputs": {
         "flake-utils": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "dream2nix",
           "flake-utils-pre-commit"
         ],
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "dream2nix",
           "nixpkgs"
         ]
@@ -7593,12 +8136,12 @@
     "pre-commit-hooks_3": {
       "inputs": {
         "flake-utils": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "dream2nix",
           "flake-utils-pre-commit"
         ],
         "nixpkgs": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "dream2nix",
           "nixpkgs"
         ]
@@ -7637,8 +8180,8 @@
       "inputs": {
         "deadnix": "deadnix_2",
         "make-shell": "make-shell_2",
-        "nixpkgs": "nixpkgs_30",
-        "utils": "utils_7"
+        "nixpkgs": "nixpkgs_35",
+        "utils": "utils_8"
       },
       "locked": {
         "lastModified": 1658374818,
@@ -7678,10 +8221,10 @@
         "docs-search": "docs-search",
         "get-flake": "get-flake",
         "make-shell": "make-shell",
-        "nixpkgs": "nixpkgs_26",
+        "nixpkgs": "nixpkgs_31",
         "ps-tools": "ps-tools",
         "statix": "statix",
-        "utils": "utils_8"
+        "utils": "utils_9"
       },
       "locked": {
         "lastModified": 1660096337,
@@ -7717,12 +8260,12 @@
     },
     "root": {
       "inputs": {
-        "cardano-app-template": "cardano-app-template",
         "dana-circulating-supply": "dana-circulating-supply",
         "danaswapstats": "danaswapstats",
         "hci-effects": "hci-effects_2",
+        "hello-cardano-template": "hello-cardano-template",
         "nixinate": "nixinate",
-        "nixpkgs": "nixpkgs_39"
+        "nixpkgs": "nixpkgs_40"
       }
     },
     "rust-analyzer-src": {
@@ -7892,6 +8435,22 @@
     "stackage_10": {
       "flake": false,
       "locked": {
+        "lastModified": 1659921295,
+        "narHash": "sha256-7+4ywHfEXT9BW2YCTuVmRe/874U8DecPO8FmG1IDzzk=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "c0d746c9b8d1b0125a25cebbec577a78997d4c2a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_11": {
+      "flake": false,
+      "locked": {
         "lastModified": 1654046327,
         "narHash": "sha256-IxX46Dh4OZpF3k7KPMa3tZSScYYGqFxXpCnMc0QRkuQ=",
         "owner": "input-output-hk",
@@ -7908,11 +8467,11 @@
     "stackage_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1643073493,
-        "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
+        "lastModified": 1649639721,
+        "narHash": "sha256-i/nyHyfpvw6en4phdjLS96DhJI95MVX3KubfUJwDtuU=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "48e1188855ca38f3b7e2a8dba5352767a2f0a8f7",
+        "rev": "9d1954e8bf7ce40ce21d59794d19a8d1ddf06cd6",
         "type": "github"
       },
       "original": {
@@ -7972,6 +8531,22 @@
     "stackage_6": {
       "flake": false,
       "locked": {
+        "lastModified": 1643073493,
+        "narHash": "sha256-5cPd1+i/skvJY9vJO1BhVRPcJObqkxDSywBEppDmb1U=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "48e1188855ca38f3b7e2a8dba5352767a2f0a8f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
+    "stackage_7": {
+      "flake": false,
+      "locked": {
         "lastModified": 1655687733,
         "narHash": "sha256-/Ngfyu0IFzCD21xjxXxcKvhPc5qEXEufWuF5oBbe+IU=",
         "owner": "input-output-hk",
@@ -7985,7 +8560,7 @@
         "type": "github"
       }
     },
-    "stackage_7": {
+    "stackage_8": {
       "flake": false,
       "locked": {
         "lastModified": 1653355076,
@@ -8001,7 +8576,7 @@
         "type": "github"
       }
     },
-    "stackage_8": {
+    "stackage_9": {
       "flake": false,
       "locked": {
         "lastModified": 1655255731,
@@ -8017,27 +8592,11 @@
         "type": "github"
       }
     },
-    "stackage_9": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1659921295,
-        "narHash": "sha256-7+4ywHfEXT9BW2YCTuVmRe/874U8DecPO8FmG1IDzzk=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "c0d746c9b8d1b0125a25cebbec577a78997d4c2a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
     "statix": {
       "inputs": {
         "fenix": "fenix_3",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_31"
+        "nixpkgs": "nixpkgs_36"
       },
       "locked": {
         "lastModified": 1657460333,
@@ -8072,8 +8631,8 @@
     },
     "tailwind-haskell": {
       "inputs": {
-        "flake-utils": "flake-utils_11",
-        "nixpkgs": "nixpkgs_10"
+        "flake-utils": "flake-utils_12",
+        "nixpkgs": "nixpkgs_15"
       },
       "locked": {
         "lastModified": 1654211622,
@@ -8093,14 +8652,14 @@
     "tailwind-haskell_2": {
       "inputs": {
         "ema": [
-          "cardano-app-template",
+          "hello-cardano-template",
           "plutarch",
           "emanote",
           "ema"
         ],
-        "flake-compat": "flake-compat_10",
-        "flake-utils": "flake-utils_17",
-        "nixpkgs": "nixpkgs_18"
+        "flake-compat": "flake-compat_12",
+        "flake-utils": "flake-utils_18",
+        "nixpkgs": "nixpkgs_23"
       },
       "locked": {
         "lastModified": 1653230344,
@@ -8243,11 +8802,11 @@
     },
     "utils_5": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
         "type": "github"
       },
       "original": {
@@ -8272,8 +8831,23 @@
       }
     },
     "utils_7": {
+      "locked": {
+        "lastModified": 1653893745,
+        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_8": {
       "inputs": {
-        "flake-utils": "flake-utils_19"
+        "flake-utils": "flake-utils_20"
       },
       "locked": {
         "lastModified": 1656044990,
@@ -8290,9 +8864,9 @@
         "type": "github"
       }
     },
-    "utils_8": {
+    "utils_9": {
       "inputs": {
-        "flake-utils": "flake-utils_20"
+        "flake-utils": "flake-utils_21"
       },
       "locked": {
         "lastModified": 1656044990,
@@ -8346,10 +8920,10 @@
     "yubihsm": {
       "inputs": {
         "bech32": "bech32",
-        "flake-compat": "flake-compat_11",
-        "flake-utils": "flake-utils_21",
+        "flake-compat": "flake-compat_13",
+        "flake-utils": "flake-utils_22",
         "nci": "nci",
-        "nixpkgs": "nixpkgs_34"
+        "nixpkgs": "nixpkgs_39"
       },
       "locked": {
         "lastModified": 1664987800,

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
 
     danaswapstats.url = "git+ssh://git@github.com/ArdanaLabs/danaswapstats";
     dana-circulating-supply.url = "git+ssh://git@github.com/ArdanaLabs/dana-circulating-supply?ref=main";
-    cardano-app-template.url = "github:ArdanaLabs/cardano-app-template/hello-world-nixos-module";
+    hello-cardano-template.url = "github:ArdanaLabs/hello-cardano-template/hello-world-nixos-module";
   };
   outputs = {
     self,
@@ -24,7 +24,7 @@
     mkTenantSystem = {
       danaswapstats,
       dana-circulating-supply,
-      cardano-app-template,
+      hello-cardano-template,
       nixpkgs,
       ...
     }@inputs:
@@ -35,7 +35,7 @@
           (import ./mixins/common.nix)
           danaswapstats.nixosModules.danaswapstats
           dana-circulating-supply.nixosModules.dana-circulating-supply
-          cardano-app-template.nixosModules.hello-world
+          hello-cardano-template.nixosModules.hello-world
           {
             _module.args = {
                nixinate = {


### PR DESCRIPTION
This updated revision uses the latest cardano-node release version 1.35.3